### PR TITLE
chore: Update WTIndex address in ropsten to the current version

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "gasMargin": 1.5,
-  "indexAddress": "0x787593b0A1020FD796312B5D284Ee64a0947cc52",
+  "indexAddress": "0x09C0AECBA9BBEBCCDAAF3FE8473591A69C4C11BE",
   "port": 3000,
   "privateKeyDir": "keys/mainKey.json",
   "web3Provider": "https://ropsten.infura.io/WKNyJ0kClh8Ao5LdmO7z",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,9 +66,9 @@
       }
     },
     "@windingtree/wt-js-libs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@windingtree/wt-js-libs/-/wt-js-libs-0.1.0.tgz",
-      "integrity": "sha512-IPMsAyxJRe1UzoYfGNIOJSgcscUgJ/rQujIhcrsq3CwmzLxQW7ed6epf1GmB1bVCfduS5qhhFFhV/KIqpX69Ww==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@windingtree/wt-js-libs/-/wt-js-libs-0.1.2.tgz",
+      "integrity": "sha512-em/Aa1uSsZjZvR8qJntjjUjwV+Nk9O0ENvQzqj7jS8sNo7/eqMvI7z386LDawZKXZRLwgfLm+lCxiR5bng6zpQ==",
       "requires": {
         "@windingtree/lif-token": "0.1.2-erc827",
         "@windingtree/wt-contracts": "0.1.0",
@@ -81,7 +81,7 @@
         "moment": "2.21.0",
         "superagent": "3.8.2",
         "web3": "1.0.0-beta.26",
-        "web3-eth-abi": "1.0.0-beta.30",
+        "web3-eth-abi": "1.0.0-beta.31",
         "zeppelin-solidity": "1.7.0"
       },
       "dependencies": {
@@ -91,39 +91,39 @@
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         },
         "web3-core-helpers": {
-          "version": "1.0.0-beta.30",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.30.tgz",
-          "integrity": "sha1-oADO4/CgnuoT10tXMDNdRjX+Hy8=",
+          "version": "1.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.31.tgz",
+          "integrity": "sha1-cETI89P3NRWLoeZrhPbECQiCFlw=",
           "requires": {
             "underscore": "1.8.3",
-            "web3-eth-iban": "1.0.0-beta.30",
-            "web3-utils": "1.0.0-beta.30"
+            "web3-eth-iban": "1.0.0-beta.31",
+            "web3-utils": "1.0.0-beta.31"
           }
         },
         "web3-eth-abi": {
-          "version": "1.0.0-beta.30",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.30.tgz",
-          "integrity": "sha1-bqUsmZqFBbR8L4i6YdKmgKEGZAk=",
+          "version": "1.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.31.tgz",
+          "integrity": "sha1-xQ457cINFrTDWQKegpuEE5THL8E=",
           "requires": {
             "bn.js": "4.11.6",
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.30",
-            "web3-utils": "1.0.0-beta.30"
+            "web3-core-helpers": "1.0.0-beta.31",
+            "web3-utils": "1.0.0-beta.31"
           }
         },
         "web3-eth-iban": {
-          "version": "1.0.0-beta.30",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.30.tgz",
-          "integrity": "sha1-OwgKXE2h+jdHexfkyQB4G5IVBkU=",
+          "version": "1.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.31.tgz",
+          "integrity": "sha1-7WS+0zO7BApvKU+06dGOrdvr/8o=",
           "requires": {
             "bn.js": "4.11.6",
-            "web3-utils": "1.0.0-beta.30"
+            "web3-utils": "1.0.0-beta.31"
           }
         },
         "web3-utils": {
-          "version": "1.0.0-beta.30",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.30.tgz",
-          "integrity": "sha1-6uQIzI1tb+zI1Ql8/q1Rdz8jH/k=",
+          "version": "1.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.31.tgz",
+          "integrity": "sha1-DxgSXT6WmK6Cy/b6Ka3B4WFvKTY=",
           "requires": {
             "bn.js": "4.11.6",
             "eth-lib": "0.1.27",
@@ -977,7 +977,7 @@
         "babylon": "6.18.0",
         "debug": "2.6.9",
         "globals": "9.18.0",
-        "invariant": "2.2.3",
+        "invariant": "2.2.4",
         "lodash": "4.17.5"
       },
       "dependencies": {
@@ -1168,7 +1168,7 @@
         "isobject": "3.0.1",
         "kind-of": "6.0.2",
         "repeat-element": "1.1.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "snapdragon-node": "2.1.1",
         "split-string": "3.1.0",
         "to-regex": "3.0.2"
@@ -2525,7 +2525,7 @@
         "ethereum-common": "0.2.0",
         "ethereumjs-tx": "1.3.4",
         "ethereumjs-util": "5.1.5",
-        "merkle-patricia-tree": "2.3.0"
+        "merkle-patricia-tree": "2.3.1"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -2605,7 +2605,7 @@
         "ethereumjs-util": "5.1.5",
         "fake-merkle-patricia-tree": "1.0.1",
         "functional-red-black-tree": "1.0.1",
-        "merkle-patricia-tree": "2.3.0",
+        "merkle-patricia-tree": "2.3.1",
         "rustbn.js": "0.1.2",
         "safe-buffer": "5.1.1"
       },
@@ -2723,7 +2723,7 @@
         "extend-shallow": "2.0.1",
         "posix-character-classes": "0.1.1",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -2891,7 +2891,7 @@
         "extend-shallow": "2.0.1",
         "fragment-cache": "0.2.1",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -4344,9 +4344,9 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
     },
     "invariant": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
-      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -5199,9 +5199,9 @@
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merkle-patricia-tree": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.0.tgz",
-      "integrity": "sha512-LKd2OoIT9Re/OG38zXbd5pyHIk2IfcOUczCwkYXl5iJIbufg9nqpweh66VfPwMkUlrEvc7YVvtQdmSrB9V9TkQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
+      "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
       "requires": {
         "async": "1.5.2",
         "ethereumjs-util": "5.1.5",
@@ -5255,7 +5255,7 @@
         "nanomatch": "1.2.9",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -5468,7 +5468,7 @@
         "kind-of": "6.0.2",
         "object.pick": "1.3.0",
         "regex-not": "1.0.2",
-        "snapdragon": "0.8.1",
+        "snapdragon": "0.8.2",
         "to-regex": "3.0.2"
       },
       "dependencies": {
@@ -5525,7 +5525,7 @@
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.3",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
+        "stream-http": "2.8.1",
         "string_decoder": "1.0.3",
         "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
@@ -6533,14 +6533,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "set-getter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
-      "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
-    },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -6645,9 +6637,9 @@
       }
     },
     "snapdragon": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
-      "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
         "base": "0.11.2",
         "debug": "2.6.9",
@@ -6656,7 +6648,7 @@
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
         "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
+        "use": "3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -6765,9 +6757,9 @@
       }
     },
     "solc": {
-      "version": "0.4.20",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.20.tgz",
-      "integrity": "sha512-LrP3Jp4FS3y8sduIR67y8Ss1riR3fggk5sMnx4OSCcU88Ro0e51+KVXyfH3NP6ghLo7COrLx/lGUaDDugCzdgA==",
+      "version": "0.4.21",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.21.tgz",
+      "integrity": "sha512-8lJmimVjOG9AJOQRWS2ph4rSctPMsPGZ4H360HLs5iI+euUlt7iAvUxSLeFZZzwk0kas4Qta7HmlMXNU3yYwhw==",
       "requires": {
         "fs-extra": "0.30.0",
         "memorystream": "0.3.1",
@@ -7092,9 +7084,9 @@
       }
     },
     "stream-http": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
-      "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
+      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
       "requires": {
         "builtin-status-codes": "3.0.0",
         "inherits": "2.0.3",
@@ -7782,81 +7774,17 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "use": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
-      "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+      "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
       "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
+        "kind-of": "6.0.2"
       },
       "dependencies": {
-        "define-property": {
-          "version": "0.2.5",
-          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
-        },
         "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        },
-        "lazy-cache": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
-          "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-          "requires": {
-            "set-getter": "0.1.0"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -8168,7 +8096,7 @@
         "isomorphic-fetch": "2.2.1",
         "request": "2.83.0",
         "semaphore": "1.1.0",
-        "solc": "0.4.20",
+        "solc": "0.4.21",
         "tape": "4.9.0",
         "web3": "0.16.0",
         "xhr": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/windingtree/wt-nodejs-api#readme",
   "dependencies": {
-    "@windingtree/wt-js-libs": "^0.1.0",
+    "@windingtree/wt-js-libs": "^0.1.2",
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "swagger-ui-express": "^2.0.11",


### PR DESCRIPTION
WTIndex was re-deployed to ropsten with the latest version of Hotel implementation that is in line with wt-js-libs. Also bumps wt-js-libs to the most up-to-date patch version (that fixes the etherscan communication).