### PR TITLE
chore: Release 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wt-nodejs-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "eslint": "./node_modules/.bin/eslint src/ tests/",
     "test": "npm run eslint && scripts/test.sh",
+    "now-start": "npm run dev",
     "dev": "node ./src/srv/index.js",
     "deploy": "now -e NODE_ENV=production --token $NOW_TOKEN --npm --public",
     "alias": "now alias --token=$NOW_TOKEN"
@@ -49,7 +50,7 @@
     "node": "8.9.4"
   },
   "now": {
-  "name": "wt-nodejs-api",
-  "alias": "demo-api.windingtree.com"
+    "name": "wt-nodejs-api",
+    "alias": "demo-api.windingtree.com"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wt-nodejs-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": " API to interact with the Winding Tree platform",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Merge this pull request
- After merging, manually tag the resulting merge commit with `v0.1.1`
- Push the tag on github
- TravisCI releases package on github pages (again, hopefully :)) and deploys it to now

We were missing the startup command for now hosting in the last release and so the deployment did not work. As per the documentation, it should not matter which port the node app exposes, so I've just aliased the `dev` command. Hopefully it will work this time.