### PR TITLE
fix: Swagger docs use https and a live and deployed domain

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -18,9 +18,9 @@
     "url": "https://windingtree.github.io/wt-js-libs/"
   },
   "schemes": [
-    "http"
+    "https"
   ],
-  "host": "localhost:3000",
+  "host": "demo-api.windingtree.com",
   "basePath": "/",
   "tags": [
     {


### PR DESCRIPTION
Closes #105 