### PR TITLE
fix: Properly handle generic errors.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ app.get('/', (req, res) => {
   const response = {
     docs: 'https://github.com/windingtree/wt-nodejs-api/blob/master/README.md',
     info: 'https://github.com/windingtree/wt-nodejs-api',
-    version: slkjdf,
+    version,
   };
   res.status(200).json(response);
 });

--- a/src/app.js
+++ b/src/app.js
@@ -22,6 +22,26 @@ app.use(hotelsRouter);
 app.use(transactionsRouter);
 app.use(walletsRouter);
 
+// Root handler
+app.get('/', (req, res) => {
+  const response = {
+    docs: 'https://github.com/windingtree/wt-nodejs-api/blob/master/README.md',
+    info: 'https://github.com/windingtree/wt-nodejs-api',
+    version: slkjdf,
+  };
+  res.status(200).json(response);
+});
+
+// 404 handler
+app.use('*', (req, res) => {
+  res.status(404).json({
+    status: 404,
+    code: '#notFound',
+    short: 'Page not found',
+    long: 'This endpoint does not exist',
+  });
+});
+
 // Error handler
 app.use((err, req, res, next) => {
   if (config.get('log')) {
@@ -43,25 +63,6 @@ app.use((err, req, res, next) => {
   });
 });
 
-// Root handler
-app.get('/', (req, res) => {
-  const response = {
-    docs: 'https://github.com/windingtree/wt-nodejs-api/blob/master/README.md',
-    info: 'https://github.com/windingtree/wt-nodejs-api',
-    version,
-  };
-  res.status(200).json(response);
-});
-
-// 404 handler
-app.use('*', (req, res) => {
-  res.status(404).json({
-    status: 404,
-    code: '#notFound',
-    short: 'Page not found',
-    long: 'This endpoint does not exist',
-  });
-});
 
 module.exports = {
   app,

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -16,7 +16,7 @@ function handleApplicationError (code, e) {
   e.status = desc.status;
   e.code = `#${code}`;
   e.short = desc.short;
-  e.long = e.message || desc.long;
+  e.long = (code === 'genericError') ? desc.long : (e.message || desc.long);
   return e;
 }
 


### PR DESCRIPTION
This should fix two problems:

a) The assumed error handling didn't really work in the general case (which can be easily shown by introducing an error in the root handler and observing the response) because of handler/middleware ordering.

b) From a security perspective, it is bad practice to leak detailed information about unexpected errors to the API consumer, especially with full traceback included. 