### PR TITLE
feat(pagination): Hides next property when there is no next page

### DIFF
--- a/src/services/pagination.js
+++ b/src/services/pagination.js
@@ -20,9 +20,12 @@ const paginate = (items, limit = DEFAULT_PAGE_SIZE, page = 0) => {
   if (start > items.length) {
     throw new Error('Pagination outside of the limits.');
   }
+  const total = items.length;
+  let next;
   items = items.slice(start, start + limit);
-  const next = `limit=${limit}&page=${page + 1}`;
-
+  if (start + limit < total) {
+    next = `limit=${limit}&page=${page + 1}`;
+  }
   return { items, next };
 };
 

--- a/test/services/pagination.spec.js
+++ b/test/services/pagination.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
 const { expect } = require('chai');
 const { paginate } = require('../../src/services/pagination');
 
@@ -100,9 +101,18 @@ describe('Pagination', function () {
     });
 
     it('should not panic when limit and page are passed as strings', async () => {
-      const { items, next } = paginate(allItems, '1', '0');
-      expect(items).to.have.property('length', 1);
-      expect(next).to.be.eql('limit=1&page=1');
+      const { items, next } = paginate(allItems, '7', '0');
+      expect(items).to.have.property('length', 7);
+      expect(next).to.be.eql('limit=7&page=1');
+    });
+
+    it('should not provide next if there is no next page', async () => {
+      let { items, next } = paginate(allItems, 110);
+      expect(items).to.have.property('length', 100);
+      expect(next).to.be.undefined;
+      const result = paginate(allItems, 100);
+      expect(result.items).to.have.property('length', 100);
+      expect(result.next).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
It does not make sense to declare a `next` property when paginating requests when there are no real items present at that page.