### PR TITLE
feat: Changes pagination mechanics

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -34,6 +34,15 @@
             }
           },
           {
+            "name": "startWith",
+            "in": "query",
+            "description": "The first record that will be included in the result",
+            "required": false,
+            "schema": {
+              "$ref": "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType"
+            }
+          },
+          {
             "name": "fields",
             "in": "query",
             "description": "List of fields to return with the hotel item. Selecting only `id` field leads to fastest responses as all data are  trieved from WTIndex only.\n",

--- a/scripts/local-network.js
+++ b/scripts/local-network.js
@@ -48,7 +48,7 @@ const deployFullHotel = async (offChainDataAdapter, index, hotelDescription, rat
     from: accounts[0],
     gas: 6000000,
   });
-  return registerResult.logs[0].args.hotel;
+  return web3.utils.toChecksumAddress(registerResult.logs[0].args.hotel);
 };
 
 module.exports = {

--- a/src/config/local.js
+++ b/src/config/local.js
@@ -7,6 +7,7 @@ const { deployIndex } = require('../../scripts/local-network');
 const winston = require('winston');
 module.exports = {
   port: 3000,
+  baseUrl: 'http://localhost:3000',
   wtIndexAddress: 'will-be-set-during-init',
   wtLibs: WtJsLibs.createInstance({
     dataModelOptions: {

--- a/src/config/ropsten.js
+++ b/src/config/ropsten.js
@@ -6,6 +6,7 @@ const winston = require('winston');
 module.exports = {
   wtIndexAddress: '0x09C0AECBA9BBEBCCDAAF3FE8473591A69C4C11BE',
   port: 3000,
+  baseUrl: process.env.BASE_URL || 'https://demo-api.windingtree.com',
   wtLibs: WtJsLibs.createInstance({
     dataModelOptions: {
       provider: 'https://ropsten.infura.io/WKNyJ0kClh8Ao5LdmO7z',

--- a/src/config/test.js
+++ b/src/config/test.js
@@ -4,6 +4,7 @@ const winston = require('winston');
 
 module.exports = {
   port: 8100,
+  baseUrl: 'http://example.com',
   wtIndexAddress: 'will-be-set-during-init',
   wtLibs: WtJsLibs.createInstance({
     dataModelOptions: {
@@ -27,7 +28,7 @@ module.exports = {
     level: 'debug',
     transports: [
       new winston.transports.Console({
-        silent: true
+        silent: true,
       }),
     ],
   }),

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -72,8 +72,7 @@ const findAll = async (req, res, next) => {
 
   try {
     let hotels = await res.locals.wt.index.getAllHotels();
-
-    let { items, next } = paginate(hotels, limit, page);
+    let { items, next } = paginate(req.path, hotels, limit, page);
     let rawHotels = [];
     for (let hotel of items) {
       rawHotels.push(resolveHotelObject(hotel, fields));

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -11,7 +11,11 @@ const {
   mapHotelObjectToResponse,
   mapHotelFieldsFromQuery,
 } = require('../services/property-mapping');
-const { paginate } = require('../services/pagination');
+const {
+  paginate,
+  LimitValidationError,
+  MissingStartWithError,
+} = require('../services/pagination');
 
 // Helpers
 
@@ -66,13 +70,13 @@ const calculateFields = (fieldsQuery) => {
 // Actual controllers
 
 const findAll = async (req, res, next) => {
-  const { limit, page } = req.query;
+  const { limit, startWith } = req.query;
   const fieldsQuery = req.query.fields || DEFAULT_HOTELS_FIELDS;
   const fields = calculateFields(fieldsQuery);
 
   try {
     let hotels = await res.locals.wt.index.getAllHotels();
-    let { items, next } = paginate(req.path, hotels, limit, page);
+    let { items, next } = paginate(req.path, hotels, limit, startWith, 'address');
     let rawHotels = [];
     for (let hotel of items) {
       rawHotels.push(resolveHotelObject(hotel, fields));
@@ -80,17 +84,11 @@ const findAll = async (req, res, next) => {
     items = await Promise.all(rawHotels);
     res.status(200).json({ items, next });
   } catch (e) {
-    if (e.message.match(/limit and page are not numbers/i)) {
-      return next(handleApplicationError('paginationFormat', e));
+    if (e instanceof LimitValidationError) {
+      return next(handleApplicationError('paginationLimitError', e));
     }
-    if (e.message.match(/Limit out of range/i)) {
-      return next(handleApplicationError('limitRange', e));
-    }
-    if (e.message.match(/Pagination outside of the limits./i)) {
-      return next(handleApplicationError('paginationLimit', e));
-    }
-    if (e.message.match(/Negative Page./i)) {
-      return next(handleApplicationError('negativePage', e));
+    if (e instanceof MissingStartWithError) {
+      return next(handleApplicationError('paginationStartWithError', e));
     }
     next(e);
   }

--- a/src/errors/codes.js
+++ b/src/errors/codes.js
@@ -28,25 +28,15 @@ module.exports = {
     short: 'Checksum failed for hotel address.',
     long: 'Given hotel address is not a valid Ethereum address. Must be a valid checksum address.',
   },
-  limitRange: {
+  paginationLimitError: {
     status: 422,
-    short: 'Limit must be a natural number.',
-    long: 'Limit must be greater than 0.',
+    short: 'Bad limit parameter.',
+    long: 'Limit must be a natural number greater than 0.',
   },
-  paginationLimit: {
-    status: 422,
-    short: 'The page exceed the number of hotels.',
-    long: 'The first item of the page is beyond the amount of hotels.',
-  },
-  paginationFormat: {
-    status: 422,
-    short: 'Page and limit must be numbers.',
-    long: 'Limit must be a natural number. Page must be greater than 0s.',
-  },
-  negativePage: {
-    status: 422,
-    short: 'Page must be great than or equal to zero.',
-    long: 'Limit must be a natural number. Page must be greater than 0s.',
+  paginationStartWithError: {
+    status: 404,
+    short: 'startWith does not exist.',
+    long: 'Cannot find startWith in hotel collection.',
   },
   roomTypeNotFound: {
     status: 404,

--- a/src/services/pagination.js
+++ b/src/services/pagination.js
@@ -4,32 +4,48 @@ const {
   MAX_PAGE_SIZE,
 } = require('../constants');
 
-const paginate = (basePath, items, limit = DEFAULT_PAGE_SIZE, page = 0) => {
+class LimitValidationError extends Error {};
+class MissingStartWithError extends Error {};
+
+const paginate = (basePath, items, limit = DEFAULT_PAGE_SIZE, startWith, itemPaginationKey) => {
   limit = parseInt(limit);
-  page = parseInt(page);
-  if (isNaN(limit) || isNaN(page)) {
-    throw new Error('Limit and page are not numbers.');
+  if (isNaN(limit)) {
+    throw new LimitValidationError('Limit is not a number.');
   }
   if (limit > MAX_PAGE_SIZE || limit <= 0) {
-    throw new Error('Limit out of range.');
+    throw new LimitValidationError('Limit is out of range.');
   }
-  if (page < 0) {
-    throw new Error('Negative Page.');
+  if (startWith && itemPaginationKey) {
+    startWith = items.find((i) => i[itemPaginationKey] === startWith);
+    if (!startWith) {
+      throw new MissingStartWithError('Cannot find startWith in items list.');
+    }
   }
 
-  const start = page * limit;
-  if (start > items.length) {
-    throw new Error('Pagination outside of the limits.');
+  let startWithIndex = items.indexOf(startWith);
+  if (startWith && startWithIndex === -1) {
+    throw new MissingStartWithError('Cannot find startWith in items list.');
+  } else if (!startWith) {
+    startWithIndex = 0;
   }
-  const total = items.length;
+
   let next;
-  items = items.slice(start, start + limit);
-  if (start + limit < total) {
-    next = `${baseUrl}${basePath}?limit=${limit}&page=${page + 1}`;
+  if (startWithIndex + limit < items.length) {
+    let nextStart = items[startWithIndex + limit];
+    if (itemPaginationKey) {
+      nextStart = nextStart[itemPaginationKey];
+    }
+    next = `${baseUrl}${basePath}?limit=${limit}&startWith=${nextStart}`;
   }
-  return { items, next };
+  
+  return {
+    items: items.slice(startWithIndex, startWithIndex + limit),
+    next,
+  };
 };
 
 module.exports = {
   paginate,
+  LimitValidationError,
+  MissingStartWithError,
 };

--- a/src/services/pagination.js
+++ b/src/services/pagination.js
@@ -1,9 +1,10 @@
+const { baseUrl } = require('../config');
 const {
   DEFAULT_PAGE_SIZE,
   MAX_PAGE_SIZE,
 } = require('../constants');
 
-const paginate = (items, limit = DEFAULT_PAGE_SIZE, page = 0) => {
+const paginate = (basePath, items, limit = DEFAULT_PAGE_SIZE, page = 0) => {
   limit = parseInt(limit);
   page = parseInt(page);
   if (isNaN(limit) || isNaN(page)) {
@@ -24,7 +25,7 @@ const paginate = (items, limit = DEFAULT_PAGE_SIZE, page = 0) => {
   let next;
   items = items.slice(start, start + limit);
   if (start + limit < total) {
-    next = `limit=${limit}&page=${page + 1}`;
+    next = `${baseUrl}${basePath}?limit=${limit}&page=${page + 1}`;
   }
   return { items, next };
 };

--- a/test/services/pagination.spec.js
+++ b/test/services/pagination.spec.js
@@ -1,7 +1,9 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 const { expect } = require('chai');
-const { paginate } = require('../../src/services/pagination');
+const { paginate, LimitValidationError,
+  MissingStartWithError,
+} = require('../../src/services/pagination');
 
 const {
   DEFAULT_PAGE_SIZE,
@@ -14,106 +16,96 @@ describe('Pagination', function () {
     allItems = new Array(100).fill(0).map((a, i) => i);
   });
 
-  describe('Paginate items', () => {
+  describe('pagination behaviour', () => {
     it('should return default number of items if not said otherwise', async () => {
       const { items, next } = paginate(basePath, allItems);
       expect(items).to.be.an('array');
       expect(items.length).to.be.eql(DEFAULT_PAGE_SIZE);
       expect(items[0]).to.be.eql(0);
       expect(items[29]).to.be.eql(29);
-      expect(next).to.be.eql(`http://example.com/hotels?limit=${DEFAULT_PAGE_SIZE}&page=1`);
+      expect(next).to.be.eql(`http://example.com/hotels?limit=${DEFAULT_PAGE_SIZE}&startWith=30`);
     });
 
-    it('should return second page', async () => {
-      const page = 1;
+    it('should start where told to', async () => {
       const limit = 30;
-      const { items, next } = paginate(basePath, allItems, limit, page);
+      const { items, next } = paginate(basePath, allItems, limit, 35);
       expect(items).to.be.an('array');
       expect(items.length).to.be.eql(limit);
-      expect(items[0]).to.be.eql(30);
-      expect(items[29]).to.be.eql(59);
-      expect(next).to.be.eql(`http://example.com/hotels?limit=${limit}&page=${page + 1}`);
-    });
-
-    it('should throw Pagination outside of the limits.', async () => {
-      const page = 130;
-      const limit = 15;
-      try {
-        paginate(basePath, allItems, limit, page);
-      } catch (e) {
-        expect(e).to.have.property('message', 'Pagination outside of the limits.');
-      }
-    });
-
-    it('should throw limit and page are not numbers.', async () => {
-      const page = 'zero';
-      const limit = 15;
-      try {
-        paginate(basePath, allItems, limit, page);
-      } catch (e) {
-        expect(e).to.have.property('message', 'Limit and page are not numbers.');
-      }
-    });
-
-    it('should throw Limit out of range for a negative limit', async () => {
-      const page = 0;
-      const limit = -1;
-      try {
-        paginate(basePath, allItems, limit, page);
-      } catch (e) {
-        expect(e).to.have.property('message', 'Limit out of range.');
-      }
-    });
-
-    it('should throw Limit out of range for limit=0', async () => {
-      const page = 0;
-      const limit = 0;
-      try {
-        paginate(basePath, allItems, limit, page);
-      } catch (e) {
-        expect(e).to.have.property('message', 'Limit out of range.');
-      }
-    });
-
-    it('should throw Limit out of range for a limit bigger than MAX_PAGE_SIZE', async () => {
-      const page = 0;
-      const limit = 1500;
-      try {
-        paginate(basePath, allItems, limit, page);
-      } catch (e) {
-        expect(e).to.have.property('message', 'Limit out of range.');
-      }
-    });
-
-    it('should throw when page is negative', async () => {
-      const page = -1;
-      const limit = 10;
-      try {
-        paginate(basePath, allItems, limit, page);
-      } catch (e) {
-        expect(e).to.have.property('message', 'Negative Page.');
-      }
+      expect(items[0]).to.be.eql(35);
+      expect(items[29]).to.be.eql(64);
+      expect(next).to.be.eql(`http://example.com/hotels?limit=${limit}&startWith=65`);
     });
 
     it('should return 1 item', async () => {
       const { items, next } = paginate(basePath, allItems, 1);
       expect(items).to.have.property('length', 1);
-      expect(next).to.be.eql('http://example.com/hotels?limit=1&page=1');
+      expect(items[0]).to.be.equal(0);
+      expect(next).to.be.eql('http://example.com/hotels?limit=1&startWith=1');
     });
 
-    it('should not panic when limit and page are passed as strings', async () => {
-      const { items, next } = paginate(basePath, allItems, '7', '0');
-      expect(items).to.have.property('length', 7);
-      expect(next).to.be.eql('http://example.com/hotels?limit=7&page=1');
-    });
-
-    it('should not provide next if there is no next page', async () => {
+    it('should not provide next if there are no more records', async () => {
       let { items, next } = paginate(basePath, allItems, 110);
       expect(items).to.have.property('length', 100);
       expect(next).to.be.undefined;
       const result = paginate(basePath, allItems, 100);
       expect(result.items).to.have.property('length', 100);
       expect(result.next).to.be.undefined;
+    });
+
+    it('should work with itemPaginationKey', async () => {
+      let { items, next } = paginate(basePath, [{ a: 'a', b: 'b' }, { a: 'c', b: 'd' }], 1, null, 'b');
+      expect(items).to.have.property('length', 1);
+      expect(next).to.be.equal('http://example.com/hotels?limit=1&startWith=d');
+    });
+
+    it('should throw if selected startWith is not in items', async () => {
+      expect(() => {
+        paginate(basePath, allItems, 30, 'random0index');
+      }).to.throw(MissingStartWithError, 'Cannot find startWith in items list.');
+    });
+
+    it('should throw if selected startWith is not in items with itemPaginationKey', async () => {
+      expect(() => {
+        paginate(basePath, [{ a: 'a', b: 'b' }, { a: 'c', b: 'd' }], 1, 'x', 'b');
+      }).to.throw(MissingStartWithError, 'Cannot find startWith in items list.');
+    });
+  });
+
+  describe('limit validation', () => {
+    it('should throw if limit is not a number', async () => {
+      const limit = 'zerp';
+      expect(() => {
+        paginate(basePath, allItems, limit);
+      }).to.throw(LimitValidationError, 'Limit is not a number.');
+    });
+
+    it('should throw Limit out of range for a negative limit', async () => {
+      const limit = -3;
+      expect(() => {
+        paginate(basePath, allItems, limit);
+      }).to.throw(LimitValidationError, 'Limit is out of range.');
+    });
+
+    it('should throw Limit out of range for limit=0', async () => {
+      const limit = 0;
+      expect(() => {
+        paginate(basePath, allItems, limit);
+      }).to.throw(LimitValidationError, 'Limit is out of range.');
+    });
+
+    it('should throw Limit out of range for a limit bigger than MAX_PAGE_SIZE', async () => {
+      const limit = 1500;
+      expect(() => {
+        paginate(basePath, allItems, limit);
+      }).to.throw(LimitValidationError, 'Limit is out of range.');
+    });
+
+    it('should not panic when limit is passed as a string', async () => {
+      const { items, next } = paginate(basePath, allItems, '7');
+      expect(items).to.have.property('length', 7);
+      expect(items[0]).to.be.equal(0);
+      expect(items[6]).to.be.equal(6);
+      expect(next).to.be.eql('http://example.com/hotels?limit=7&startWith=7');
     });
   });
 });

--- a/test/services/pagination.spec.js
+++ b/test/services/pagination.spec.js
@@ -8,37 +8,38 @@ const {
 } = require('../../src/constants');
 
 describe('Pagination', function () {
-  let allItems = [];
+  let allItems = [],
+    basePath = '/hotels';
   beforeEach(() => {
     allItems = new Array(100).fill(0).map((a, i) => i);
   });
 
   describe('Paginate items', () => {
     it('should return default number of items if not said otherwise', async () => {
-      const { items, next } = paginate(allItems);
+      const { items, next } = paginate(basePath, allItems);
       expect(items).to.be.an('array');
       expect(items.length).to.be.eql(DEFAULT_PAGE_SIZE);
       expect(items[0]).to.be.eql(0);
       expect(items[29]).to.be.eql(29);
-      expect(next).to.be.eql(`limit=${DEFAULT_PAGE_SIZE}&page=1`);
+      expect(next).to.be.eql(`http://example.com/hotels?limit=${DEFAULT_PAGE_SIZE}&page=1`);
     });
 
     it('should return second page', async () => {
       const page = 1;
       const limit = 30;
-      const { items, next } = paginate(allItems, limit, page);
+      const { items, next } = paginate(basePath, allItems, limit, page);
       expect(items).to.be.an('array');
       expect(items.length).to.be.eql(limit);
       expect(items[0]).to.be.eql(30);
       expect(items[29]).to.be.eql(59);
-      expect(next).to.be.eql(`limit=${limit}&page=${page + 1}`);
+      expect(next).to.be.eql(`http://example.com/hotels?limit=${limit}&page=${page + 1}`);
     });
 
     it('should throw Pagination outside of the limits.', async () => {
       const page = 130;
       const limit = 15;
       try {
-        paginate(allItems, limit, page);
+        paginate(basePath, allItems, limit, page);
       } catch (e) {
         expect(e).to.have.property('message', 'Pagination outside of the limits.');
       }
@@ -48,7 +49,7 @@ describe('Pagination', function () {
       const page = 'zero';
       const limit = 15;
       try {
-        paginate(allItems, limit, page);
+        paginate(basePath, allItems, limit, page);
       } catch (e) {
         expect(e).to.have.property('message', 'Limit and page are not numbers.');
       }
@@ -58,7 +59,7 @@ describe('Pagination', function () {
       const page = 0;
       const limit = -1;
       try {
-        paginate(allItems, limit, page);
+        paginate(basePath, allItems, limit, page);
       } catch (e) {
         expect(e).to.have.property('message', 'Limit out of range.');
       }
@@ -68,7 +69,7 @@ describe('Pagination', function () {
       const page = 0;
       const limit = 0;
       try {
-        paginate(allItems, limit, page);
+        paginate(basePath, allItems, limit, page);
       } catch (e) {
         expect(e).to.have.property('message', 'Limit out of range.');
       }
@@ -78,7 +79,7 @@ describe('Pagination', function () {
       const page = 0;
       const limit = 1500;
       try {
-        paginate(allItems, limit, page);
+        paginate(basePath, allItems, limit, page);
       } catch (e) {
         expect(e).to.have.property('message', 'Limit out of range.');
       }
@@ -88,29 +89,29 @@ describe('Pagination', function () {
       const page = -1;
       const limit = 10;
       try {
-        paginate(allItems, limit, page);
+        paginate(basePath, allItems, limit, page);
       } catch (e) {
         expect(e).to.have.property('message', 'Negative Page.');
       }
     });
 
     it('should return 1 item', async () => {
-      const { items, next } = paginate(allItems, 1);
+      const { items, next } = paginate(basePath, allItems, 1);
       expect(items).to.have.property('length', 1);
-      expect(next).to.be.eql('limit=1&page=1');
+      expect(next).to.be.eql('http://example.com/hotels?limit=1&page=1');
     });
 
     it('should not panic when limit and page are passed as strings', async () => {
-      const { items, next } = paginate(allItems, '7', '0');
+      const { items, next } = paginate(basePath, allItems, '7', '0');
       expect(items).to.have.property('length', 7);
-      expect(next).to.be.eql('limit=7&page=1');
+      expect(next).to.be.eql('http://example.com/hotels?limit=7&page=1');
     });
 
     it('should not provide next if there is no next page', async () => {
-      let { items, next } = paginate(allItems, 110);
+      let { items, next } = paginate(basePath, allItems, 110);
       expect(items).to.have.property('length', 100);
       expect(next).to.be.undefined;
-      const result = paginate(allItems, 100);
+      const result = paginate(basePath, allItems, 100);
       expect(result.items).to.have.property('length', 100);
       expect(result.next).to.be.undefined;
     });


### PR DESCRIPTION
Goal of this PR is to improve the pagination usability and lay the ground work for transparent handling of error states in a single hotel (such as off-chain data inaccessibility).

The essence is that I've dropped the `page` query parameter and replaced it with `startWith` which denotes the first ID that should be included in the `next` page if requested by a user. This will allow us to *shift* the hotels in order to be able to fulfill the requested `limit` whilst not breaking the pagination scheme.

Let's imagine this: We have 20 hotels, the first 10 of those have inaccessible off-chain data. With the offset-based pagination, the first page would be useless for any API user. With the value-based approach, the API will respond with hotels 11-20 and 10 error records, thus enabling the API user to immediately use at least something.