### PR TITLE
Inject roomTypeId in responses

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -319,16 +319,49 @@
               },
               "managerAddress": {
                 "$ref": "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/EthereumAddressType"
+              },
+              "roomTypes" : {
+                "description" : "Room types in the hotel",
+                "$ref" : "#/components/schemas/RoomTypesResponse"
               }
             }
           }
         ]
       },
-      "HotelDetail": {
-        "$ref": "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/HotelDescription"
+      "HotelDetail" : {
+        "allOf" : [
+          {
+            "$ref" : "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/HotelDescription"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "roomTypes" : {
+                "description" : "Room types in the hotel",
+                "$ref" : "#/components/schemas/RoomTypesResponse"
+              }
+            }
+          }
+        ]
       },
-      "RoomTypeResponse": {
-        "$ref": "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/RoomType"
+      "RoomTypesResponse" : {
+        "description" : "Mapping where keys are id of room types and the values are room types",
+        "type" : "object",
+        "additionalProperties" : {
+          "$ref" : "#/components/schemas/RoomTypeResponse"
+        }
+      },
+      "RoomTypeResponse" : {
+        "allOf" : [ {
+          "$ref" : "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/RoomType"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "$ref" : "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/ObjectIdType",
+              "description" : "Vendor room type ID (should be unique for hotel)"
+            },
+          }
+        } ]
       },
       "Error": {
         "title": "Error",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -359,7 +359,7 @@
             "id" : {
               "$ref" : "https://raw.githubusercontent.com/windingtree/wiki/master/hotel-data-swagger.yaml#/components/schemas/ObjectIdType",
               "description" : "Vendor room type ID (should be unique for hotel)"
-            },
+            }
           }
         } ]
       },

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -25,6 +25,11 @@ const pickAndResolveFields = (contents, fields) => {
   return fields.reduce(async (plainContent, field) => {
     plainContent = await plainContent;
     plainContent[field] = await contents[field];
+    if (field === 'roomTypes') {
+      for (let roomTypeId in plainContent[field]) {
+        plainContent[field][roomTypeId].id = roomTypeId;
+      }
+    }
     return plainContent;
   }, {});
 };

--- a/src/controllers/room-types.js
+++ b/src/controllers/room-types.js
@@ -9,6 +9,9 @@ const findAll = async (req, res, next) => {
     const indexRow = (await hotel.dataIndex).contents;
     const description = (await indexRow.descriptionUri).contents;
     let roomTypes = await description.roomTypes;
+    for (let roomTypeId in roomTypes) {
+      roomTypes[roomTypeId].id = roomTypeId;
+    }
     res.status(200).json(roomTypes);
   } catch (e) {
     next(e);
@@ -26,7 +29,7 @@ const find = async (req, res, next) => {
     if (!roomType) {
       return next(handleApplicationError('roomTypeNotFound'));
     }
-    
+    roomType.id = roomTypeId;
     res.status(200).json(roomType);
   } catch (e) {
     next(e);

--- a/test/controllers/hotels.spec.js
+++ b/test/controllers/hotels.spec.js
@@ -80,6 +80,9 @@ describe('Hotels', function () {
           expect(items.length).to.be.eql(2);
           items.forEach(hotel => {
             expect(hotel).to.have.all.keys(fields);
+            for (let roomType in hotel.roomTypes) {
+              expect(hotel.roomTypes[roomType]).to.have.property('id');
+            }
           });
         });
     });

--- a/test/controllers/room-types.spec.js
+++ b/test/controllers/room-types.spec.js
@@ -38,6 +38,9 @@ describe('Room types', function () {
         .set('accept', 'application/json')
         .expect((res) => {
           expect(res.body).to.eql(HOTEL_DESCRIPTION.roomTypes);
+          for (let roomType in res.body) {
+            expect(res.body[roomType]).to.have.property('id');
+          }
         });
     });
   });

--- a/test/utils/test-data.js
+++ b/test/utils/test-data.js
@@ -7,7 +7,6 @@ const HOTEL_DESCRIPTION = {
   'description': 'string',
   'roomTypes': {
     'room-type-1111': {
-      'id': 'room-type-1111',
       'name': 'string',
       'description': 'string',
       'totalQuantity': 0,
@@ -27,7 +26,6 @@ const HOTEL_DESCRIPTION = {
       },
     },
     'room-type-2222': {
-      'id': 'room-type-2222',
       'name': 'string',
       'description': 'string',
       'totalQuantity': 0,
@@ -47,7 +45,6 @@ const HOTEL_DESCRIPTION = {
       },
     },
     'room-type-3333': {
-      'id': 'room-type-3333',
       'name': 'string',
       'description': 'string',
       'totalQuantity': 0,


### PR DESCRIPTION
As discussed in https://github.com/windingtree/wiki/issues/39 `id` was removed from hotel data specification `roomType` structure. And should be injected in reading API.

I have updated the swagger definitions, could @MatiasOS  or @JirkaChadima  please inject these ids in responses? Thanks